### PR TITLE
Fix flowforge references & improvements to examples

### DIFF
--- a/nodes/locales/en-US/ui-example.html
+++ b/nodes/locales/en-US/ui-example.html
@@ -1,0 +1,3 @@
+<script type="text/html" data-help-name="ui-example">
+    <p>In-Editor help text will go here.</p>
+</script>

--- a/nodes/locales/en-US/ui-example.json
+++ b/nodes/locales/en-US/ui-example.json
@@ -1,0 +1,7 @@
+{
+    "ui-example" : {
+        "label": {
+            "size": "Size"
+        }
+    }
+}

--- a/nodes/ui-example.html
+++ b/nodes/ui-example.html
@@ -1,17 +1,36 @@
 <script type="text/javascript">
     RED.nodes.registerType('ui-example', {
-        category: RED._('@flowforge/node-red-dashboard/ui-base:ui-base.label.category'),
-        color: '#a6bbcf',
+        category: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.label.category'),
+        color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.light'),
         defaults: {
             name: { value: "" },
             group: { type: 'ui-group', required: true },
             example: { value: "" },
+            width: {
+                value: 0,
+                validate: function (v) {
+                    const width = v || 0
+                    const currentGroup = $('#node-input-group').val() || this.group
+                    const groupNode = RED.nodes.node(currentGroup)
+                    const valid = !groupNode || +width <= +groupNode.width
+                    $('#node-input-size').toggleClass('input-error', !valid)
+                    return valid
+                }
+            },
+            height: { value: 0 }
         },
         inputs: 1,
         outputs: 1,
         icon: "file.svg",
         label: function() {
             return this.name || "ui-example";
+        },
+        oneditprepare: function () {
+            $('#node-input-size').elementSizer({
+                width: '#node-input-width',
+                height: '#node-input-height',
+                group: '#node-input-group'
+            });
         }
     });
 </script>
@@ -26,11 +45,13 @@
         <input type="text" id="node-input-group">
     </div>
     <div class="form-row">
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui-example.label.size"></label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <div class="form-row">
         <label for="node-input-example"><i class="fa fa-hand"></i> Example</label>
         <input type="text" id="node-input-example">
     </div>
-</script>
-
-<script type="text/html" data-help-name="ui-example">
-    <p>A simple node that converts the message payloads into all lower-case characters</p>
 </script>


### PR DESCRIPTION
## Description

With the great work that @sumitshinde-84 is doing in https://github.com/sumitshinde-84/node-red-dashboard-2-ui-webcam it made me realise there were a couple of errors and a couple of obvious examples missing from this, so this PR adds them:

- Update `flowforge` to `flowfuse` to ensure it categorises correctly in the Node-RED Editor
- Demonstrate the use of the templated colour palette available in Dashboard 2.0 for choosing node colors (here with a demo of `light`)
- Add in size (width/height) option as this will be very common across other third party widgets.
- Add localisation example
- Add in-editor documentation example