### PR TITLE
Include "order" property

### DIFF
--- a/nodes/ui-example.html
+++ b/nodes/ui-example.html
@@ -5,6 +5,7 @@
         defaults: {
             name: { value: "" },
             group: { type: 'ui-group', required: true },
+            order: { value: 0 },
             example: { value: "" },
             width: {
                 value: 0,


### PR DESCRIPTION
## Description

UI Examples, and any nodes built from this, will not order correctly within a Dashboard unless an "order" property is defined on the node.

This ensure that the base example includes it so that any future 3rd party nodes inherit this.