### PR TITLE
Add install instructions for developing locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Example Node for Node-RED Dashboard
 
-This repository contains an example, third-party, node for the Node-RED Dashboard. You can read our [contribution guide](https://dashboard.flowfuse.com/contributing/widgets/third-party.html) for details on developing your own Dashboard 2.0 integrations & widgets.
+
+This repository contains an example, third-party, node for the Node-RED Dashboard. 
+
+To get started, clone this repository:
+
+```bash
+# if using HTTPS:
+git clone https://github.com/FlowFuse/node-red-dashboard-2-ui-example.git
+
+# if using SSH:
+git clone git@github.com:FlowFuse/node-red-dashboard-2-ui-example.git
+```
+
+Then, you can install it's dependencies with:
+
+```bash
+npm install
+```
+
+## Development with Dashboard 2.0
+
+You can read our [contribution guide](https://dashboard.flowfuse.com/contributing/widgets/third-party.html) for details on developing your own Dashboard 2.0 integrations & widgets.
 
 This project is intended to be used as a starting point for creating your own custom nodes that can integrate directly with [Node-RED Dashboard 2.0](https://github.com/FlowFuse/flowforge-nr-dashboard).
 


### PR DESCRIPTION
We had a link to the third-party docs for working with ui-example, within Dashboard, but we were missing instructions on developing locally in the `ui-example` repository itself.