### PR TITLE
Fix lint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-n": "^16.3.1",
         "eslint-plugin-vue": "^9.18.1",
+        "sort-package-json": "^3.4.0",
         "vite": "^5.0.13",
         "vite-plugin-css-injected-by-js": "^3.3.0",
         "vite-plugin-static-copy": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "lint": "npm run lint:js && npm run lint:package",
         "lint:fix": "npm run lint:js:fix && npm run lint:package:fix",
         "lint:js": "eslint --ext .js,.vue,.cjs,.mjs .",
-        "lint:js:fix": "yarn lint:js --fix",
+        "lint:js:fix": "npm run lint:js -- --fix",
         "lint:package": "sort-package-json --check 'package.json'",
         "lint:package:fix": "sort-package-json 'package.json'"
     },


### PR DESCRIPTION
## Description

I would like to fix the npm scripts `lint:js:fix` and `lint:package` which are not working.

- lint:js:fix : Change to use npm instead of yarn.
- lint:package : Add sort-package-json to devDependencies.

## Related Issue(s)

There are no related issues. It is a minor fix.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)

Due to minor changes in package.json, the following are not required:

 - [ ] Suitable unit/system level tests have been added and they pass 
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 
## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label
